### PR TITLE
 Config vagrant for part 2

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,6 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.yml]
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vagrant
 .vscode
 k3s_token
+kubectl.config.yml

--- a/P2/README.md
+++ b/P2/README.md
@@ -1,0 +1,18 @@
+# Vagrant, K3s and 3 little web applications
+
+In this second part of the project, we will configure 3 little webapp under k3s.
+
+The `Vagrantfile` will create a k3s cluster with a single node and copy the `kubectl` config file at the root of the folder.
+
+You can use that file with:
+
+```bash
+kubectl --kubeconfig kubectl.config.yml ...
+```
+
+or by setting the env variable
+
+```bash
+export KUBECONFIG=$(pwd)/kubectl.config.yml
+kubectl ...
+```

--- a/P2/Vagrantfile
+++ b/P2/Vagrantfile
@@ -1,0 +1,52 @@
+# The login of a member of the team.
+# Used to customize the name of the VMs.
+A_LOGIN = "ygaude"
+# The current part of the project.
+PART = 2
+
+# The name of the server VM.
+SERVER_NAME = "#{A_LOGIN}S"
+
+SERVER_IP = "192.168.56.110"
+
+Vagrant.configure(2) do |config|
+    config.vm.box = "ubuntu/jammy64"
+
+    config.vm.provider "virtualbox" do |v|
+        # Set the VM name.
+        v.customize ["modifyvm", :id, "--name", "#{SERVER_NAME}-P#{PART}"]
+        # Disable gui
+        v.gui = false
+        # Config cpu number
+        v.cpus = 2
+        # Config RAM
+        v.memory = 2048
+    end
+
+    # Set the hostname of the VM.
+    config.vm.hostname = SERVER_NAME
+
+    # Configure the IP address of the VM.
+    print "[#{SERVER_NAME}] Using IP #{SERVER_IP}\n"
+    config.vm.network "private_network", ip: SERVER_IP
+
+    # Install K3s in controller mode.
+    config.vm.provision "shell",
+        name: "Install K3s in controller mode",
+        run: "once",
+        path: "https://get.k3s.io/",
+        sha256: "704f918bc8bc56329dce985ee7964cceff3f53d3580beff99ee85d8e7da94638",
+        args: [
+            "server",
+            "--node-name=#{SERVER_NAME}-controller",
+            "--tls-san=#{SERVER_IP}",
+            "--node-ip=#{SERVER_IP}"
+        ]
+
+    config.vm.provision "shell",
+        name: "Copy kubectl config file",
+        run: "once",
+        inline: <<-SHELL
+            sed 's;server: https://127.0.0.1:6443$;server: https://#{SERVER_IP}:6443;' /etc/rancher/k3s/k3s.yaml | tee /vagrant/kubectl.config.yml
+        SHELL
+end


### PR DESCRIPTION
- Create a vm based on `ubuntu-22.04`.
- Set the ip to be `192.168.56.110`.
- Install k3s in `server` mode.
- Create a kube config file to allow to access the virtual cluster with a local `kubectl`.
- Add readme to document how to use the generated config file.