### PR TITLE
Fast argocd pooling

### DIFF
--- a/P3/files/01-argocd-cm.yml
+++ b/P3/files/01-argocd-cm.yml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cm
+  namespace: argocd
+  labels:
+    app.kubernetes.io/name: argocd-cm
+    app.kubernetes.io/part-of: argocd
+data:
+  admin.enabled: "true"
+  timeout.reconciliation: 60s

--- a/P3/files/argocd-forward.service
+++ b/P3/files/argocd-forward.service
@@ -5,6 +5,8 @@ After=network.target docker.service docker.socket
 [Service]
 Type=simple
 ExecStart=/usr/local/bin/kubectl port-forward --address=0.0.0.0 --namespace argocd service/argocd-server 9443:https
+Restart=on-failure
+RestartSec=10s
 
 [Install]
 WantedBy=multi-user.target

--- a/P3/play_k3d.yml
+++ b/P3/play_k3d.yml
@@ -158,6 +158,7 @@
         src: "{{ item }}"
       loop:
         - 01-argocd-install.yml
+        - 01-argocd-cm.yml
         - 03-wil42-argocd.yml
 
     - name: Copy system unit to port-forward argocd

--- a/P3/play_k3d.yml
+++ b/P3/play_k3d.yml
@@ -96,7 +96,13 @@
     kubeconfig_file: /vagrant/kubectl.config.yml
   tasks:
     - name: Create the k3d cluster {{ cluster_name }}
-      ansible.builtin.command: k3d cluster create --api-port {{ server_ip }}:5443 -p 8080:80@loadbalancer -p 8443:443@loadbalancer -p 8888:8888@loadbalancer ft-kube
+      ansible.builtin.command: >-
+        k3d cluster create
+        --api-port {{ server_ip }}:5443
+        -p 8080:80@loadbalancer
+        -p 8443:443@loadbalancer
+        -p 8888:8888@loadbalancer
+        ft-kube
       register: k3d_create_cluster
       changed_when: k3d_create_cluster.stdout.find("Cluster '{}' created successfully!".format(cluster_name)) != -1
       # We consider that the command have failed when the error is not that the cluster already exist.

--- a/P3/play_k3d.yml
+++ b/P3/play_k3d.yml
@@ -167,6 +167,11 @@
         - 01-argocd-cm.yml
         - 03-wil42-argocd.yml
 
+    - name: Allow vagrant'service to run after last session is closed
+      ansible.builtin.command: loginctl enable-linger vagrant
+      changed_when: false
+      become: true
+
     - name: Copy system unit to port-forward argocd
       ansible.builtin.copy:
         src: argocd-forward.service


### PR DESCRIPTION
- Add argocd config map to set `timeout.reconciliation` to a lower duration (default is `180s`).
- Format yaml to correct a too long line.
- Improve `argocd-forward` service to be always running even if `vagrant` user don't have any session